### PR TITLE
fix:missing web/public folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,7 +151,6 @@ dist
 
 # Gatsby files
 .cache/
-public
 
 # Storybook build outputs
 .out


### PR DESCRIPTION
The Docker build was failing because it couldn’t locate the web/public folder, which was listed in the .gitignore file. I’ve removed it from .gitignore, so it should work now. (minor fix) 